### PR TITLE
Deterministic Keys release

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,9 @@ As of 0.4 we now have a clojure wrapper around BitcoinJ's Deterministic Key supp
 (->path grand-child)
 # "M/2/1"
 
+;; Find the key for a particular path
+(derive-from-path mk "M/1/3")
+
 ;; Return the EC Keypair for use in signing of a Deterministic key
 (dk->kp child)
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bitcljoin "0.4.0-SNAPSHOT"
+(defproject bitcljoin "0.4.0"
   :description "BitCoin library for Clojure"
   :dependencies [
     [org.clojure/clojure "1.5.1"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bitcljoin "0.3.0"
+(defproject bitcljoin "0.4.0-SNAPSHOT"
   :description "BitCoin library for Clojure"
   :dependencies [
     [org.clojure/clojure "1.5.1"]

--- a/src/bitcoin/deterministic.clj
+++ b/src/bitcoin/deterministic.clj
@@ -1,0 +1,72 @@
+(ns bitcoin.deterministic
+  (:require [bitcoin.core :as btc])
+  (:import (com.google.bitcoin.crypto HDKeyDerivation HDUtils DeterministicKey)
+           (com.google.bitcoin.core Base58)
+           (java.security SecureRandom)
+           (bitcoin.core Addressable)))
+
+
+(defn secure-random
+  []
+  (SecureRandom.))
+
+(defonce prng (atom (secure-random)))
+
+
+(defn create-master-key
+  "Create a deterministic master"
+  ([]
+   (create-master-key (.generateSeed @prng 128)))
+  ([seed]
+   (HDKeyDerivation/createMasterPrivateKey seed)))
+
+(defn ->priv-bytes
+  [dk]
+  (.getPrivKeyBytes dk))
+
+(defn ->pub-bytes
+  [dk]
+  (.getPubKeyBytes dk))
+
+(defn ->chain-code
+  "Get the chain key used for given deterministic key"
+  [dk]
+  (.getChainCode dk))
+
+(defn dk->kp [dk]
+  (.toECKey dk))
+
+(extend-type com.google.bitcoin.crypto.DeterministicKey btc/Addressable
+  (btc/->address
+    ([dk] (btc/->address dk (btc/net)))
+    ([dk network] (.toAddress (dk->kp dk) network))))
+
+(defn serialize-pub [dk]
+  (.serializePubB58 dk))
+
+(defn serialize-priv [dk]
+  (.serializePrivB58 dk))
+
+(defn recreate-master-key
+  "Create the master key from the public key and chain code"
+  [priv chain]
+  (HDKeyDerivation/createMasterPrivKeyFromBytes priv chain))
+
+(defn recreate-master-pub-key
+  "Create the master key from the public key and chain code"
+  [pub chain]
+  (HDKeyDerivation/createMasterPubKeyFromBytes pub chain))
+
+(defn derive-key
+  "Derive a key for the derived key"
+  [dk i]
+  (HDKeyDerivation/deriveChildKey dk (.intValue i)))
+
+(defn ->pub-only
+  "Returns a derived key with only the public key part"
+  [dk]
+  (.getPubOnly dk))
+
+(defn ->path
+  [dk]
+  (.getPath dk))

--- a/src/bitcoin/deterministic.clj
+++ b/src/bitcoin/deterministic.clj
@@ -1,7 +1,6 @@
 (ns bitcoin.deterministic
   (:require [bitcoin.core :as btc])
   (:import (com.google.bitcoin.crypto HDKeyDerivation HDUtils DeterministicKey)
-           (com.google.bitcoin.core Base58)
            (java.security SecureRandom)
            (bitcoin.core Addressable)))
 
@@ -65,11 +64,11 @@
 (defn derive-from-path
   "Derive a key from a master key given a path"
   [mk path]
-
-  (if-let [items (clojure.string/split path #"/")]
-    (if (< (count items) 2)
-      mk
-      (reduce #(derive-key %1 (Long/parseLong %2)) mk (rest items)))))
+  (if (and path mk)
+    (let [items (clojure.string/split path #"/")]
+      (if (< (count items) 2)
+        mk
+        (reduce #(derive-key %1 (Long/parseLong %2)) mk (rest items))))))
 
 (defn ->pub-only
   "Returns a derived key with only the public key part"
@@ -77,5 +76,6 @@
   (.getPubOnly dk))
 
 (defn ->path
+  "Returns the path from the master key to the given key"
   [dk]
   (.getPath dk))

--- a/src/bitcoin/deterministic.clj
+++ b/src/bitcoin/deterministic.clj
@@ -62,6 +62,15 @@
   [dk i]
   (HDKeyDerivation/deriveChildKey dk (.intValue i)))
 
+(defn derive-from-path
+  "Derive a key from a master key given a path"
+  [mk path]
+
+  (if-let [items (clojure.string/split path #"/")]
+    (if (< (count items) 2)
+      mk
+      (reduce #(derive-key %1 (Long/parseLong %2)) mk (rest items)))))
+
 (defn ->pub-only
   "Returns a derived key with only the public key part"
   [dk]

--- a/test/bitcoin/test/deterministic.clj
+++ b/test/bitcoin/test/deterministic.clj
@@ -4,6 +4,12 @@
   (:require [bitcoin.core :as btc]))
 
 
+(defn same-key?
+  ([a b]
+   (same-key? a b serialize-pub))
+  ([a b t]
+   (is (= (t a) (t b)))))
+
 (deftest creating-master-key
   (let [dk (create-master-key)
         cc (->chain-code dk)
@@ -18,3 +24,17 @@
            (serialize-pub dk)))
     (is (= (btc/->address (recreate-master-pub-key pub cc))
            (btc/->address dk)))))
+
+
+(deftest hierarchies
+  (let [mk (create-master-key)]
+    (same-key? (derive-from-path mk "M") mk)
+    (same-key? (derive-from-path mk "M/1") (derive-key mk 1))
+    (same-key? (derive-from-path mk "M/2") (derive-key mk 2))
+    (same-key? (derive-from-path mk "M/1/3") (derive-key (derive-key mk 1) 3))
+
+    (let [pk (->pub-only mk)]
+      (same-key? (derive-from-path mk "M") (derive-from-path pk "M"))
+      (same-key? (derive-from-path mk "M/1") (derive-from-path pk "M/1"))
+      (same-key? (derive-from-path mk "M/2") (derive-from-path pk "M/2"))
+      (same-key? (derive-from-path mk "M/1/3") (derive-from-path pk "M/1/3")))))

--- a/test/bitcoin/test/deterministic.clj
+++ b/test/bitcoin/test/deterministic.clj
@@ -1,0 +1,20 @@
+(ns bitcoin.test.deterministic
+  (:use bitcoin.deterministic
+        clojure.test)
+  (:require [bitcoin.core :as btc]))
+
+
+(deftest creating-master-key
+  (let [dk (create-master-key)
+        cc (->chain-code dk)
+        priv (->priv-bytes dk)
+        pub (->pub-bytes dk)]
+    (is dk)
+    (is (= (serialize-pub (recreate-master-key priv cc))
+           (serialize-pub dk)))
+    (is (= (serialize-priv (recreate-master-key priv cc))
+           (serialize-priv dk)))
+    (is (= (serialize-pub (recreate-master-pub-key pub cc))
+           (serialize-pub dk)))
+    (is (= (btc/->address (recreate-master-pub-key pub cc))
+           (btc/->address dk)))))


### PR DESCRIPTION
This now includes a clojure wrapper around BitcoinJ's Deterministic Key support. Deterministic Keys are based on [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki) and allows you to recreate a key hierarchy based on a single secret and public key pair.
